### PR TITLE
Fix error in string() function

### DIFF
--- a/big_rational.js
+++ b/big_rational.js
@@ -390,7 +390,7 @@ function string(a, nr_places) {
 // then round up.
 
         remains = big_integer.abs(remains);
-        if (nr_places === undefined) {
+        if (nr_places !== undefined) {
             let [fractus, residue] = big_integer.divrem(
                 big_integer.mul(
                     remains,

--- a/big_rational.js
+++ b/big_rational.js
@@ -1,6 +1,6 @@
 // big_rational.js
 // Douglas Crockford
-// 2018-09-24
+// 2018-11-05
 
 // You can access the big rational object in your module by importing it.
 //      import big_rational from "./big_rational.js";


### PR DESCRIPTION
There is an error in the string() function from the big_rational library (in the book on page 5.7).

In the first branch of the if statement, the `nr_places` argument is expected to be defined, so the condition must be negated.

Example code to reproduce (throws "TypeError: big is undefined" but prints the correct values with this fix):

```js
import big_integer from './big_integer.js';
import big_rational from './big_rational.js';

const eight_thirds = big_rational.make(8, 3);
console.log(big_rational.string(eight_thirds)); // 2 2/3
console.log(big_rational.string(eight_thirds, big_integer.make(2))); // 2.67

const ten_thirds = big_rational.make(10, 3);
console.log(big_rational.string(ten_thirds)); // 3 1/3
console.log(big_rational.string(ten_thirds, big_integer.make(2))); // 3.33
```