### PR TITLE
Bugfix regarding additions and substractions of operands with unequal exponents

### DIFF
--- a/big_float.js
+++ b/big_float.js
@@ -98,7 +98,7 @@ function abs(a) {
 
 function conform_op(op) {
     return function (a, b) {
-        const differential = a.exponent - b.exponent;
+        const differential = b.exponent - a.exponent;
         return (
             differential === 0
             ? make_big_float(op(a.coefficient, b.coefficient), a.exponent)


### PR DESCRIPTION
The differential calculation on line 101 was incorrect, causing additions and substractions of numbers with different exponents to return wrong results. 

This fix switches the order of  the operands, which does the right thing.