### PR TITLE
Update neo.runtime.js

### DIFF
--- a/neo.runtime.js
+++ b/neo.runtime.js
@@ -147,6 +147,9 @@ function array(zeroth, wunth, ...rest) {
         );
     }
     if (Array.isArray(zeroth)) {
+        if (typeof wunth === "function") {
+            return zeroth.map(wunth);
+        }
         return zeroth.slice(big_float.number(wunth), big_float.number(rest[0]));
     }
     if (typeof zeroth === "object") {


### PR DESCRIPTION
I think in order for the array constructor to work as intended, there needs to be logic checking if the first argument is an array and the second argument is a function. If so, the second argument is used as a mapping function across the first argument.