### PR TITLE
$NEO.text returns empty string

### DIFF
--- a/neo.runtime.js
+++ b/neo.runtime.js
@@ -225,7 +225,10 @@ function record(zeroth, wunth) {
 
 function text(zeroth, wunth, twoth) {
     if (typeof zeroth === "string") {
-        return (zeroth.slice(big_float.number(wunth), big_float.number(twoth)));
+        return zeroth.slice(
+            big_float.is_big_float(wunth) ? big_float.number(wunth) : undefined,
+            big_float.is_big_float(twoth) ? big_float.number(twoth) : undefined
+        );
     }
     if (big_float.is_big_float(zeroth)) {
         return big_float.string(zeroth, wunth);


### PR DESCRIPTION
Calling `$NEO.text("hello")` returns an empty string in Chrome v83.

This is because the undefined wunth and twoth arguments are each passed to `big_float.number`, which returns `NaN` (the underlying result of `Number(undefined)`). Hence `"hello".slice(NaN, NaN)` is returned, which is an empty string.

Without this fix, the following module exports `"89"`.

```neo
def name: "terrence"
def age: 88

def have birthday: ƒ person (
    "happy birthday" ≈ person.name ≈ "! You are now " ≈ person.age + 1
)

export have birthday({ name, age })
```