### PR TITLE
Neo

### DIFF
--- a/neo.codegen.js
+++ b/neo.codegen.js
@@ -1,6 +1,6 @@
 // neo.codegen.js
 // Douglas Crockford
-// 2018-10-22
+// 2022-07-29
 
 /*property
     abs, alphameric, array, break, call, char, code, create, def, export, fail,
@@ -335,7 +335,7 @@ const functino = $NEO.stone({
     "<<": "$NEO.min",
     "*": "$NEO.mul",
     "/": "$NEO.div",
-    "[": "$NEO.get",
+    "[]": "$NEO.get",
     "(": "$NEO.resolve"
 });
 

--- a/neo.codegen.js
+++ b/neo.codegen.js
@@ -430,11 +430,24 @@ operator_transform = $NEO.stone({
                 );
             }
             return mangle(param.id);
-        }).join(", ") + ") " + (
-            Array.isArray(thing.wunth)
-            ? block(thing.wunth)
-            : "{return " + expression(thing.wunth) + ";}"
-        ) + ")";
+        }).join(", ") + ") " + (function () {
+            if (Array.isArray(thing.wunth)) {
+                if (thing.twoth !== undefined) {
+                    let padding = begin();
+                    let body;
+                    indent();
+                    body = (
+                        "{" + begin() + "try " + block(thing.wunth)
+                        + " catch (ignore) " + block(thing.twoth)
+                        + padding + "}"
+                    );
+                    outdent();
+                    return body;
+                }
+                return block(thing.wunth);
+            }
+            return "{return " + expression(thing.wunth) + ";}";
+        }()) + ")";
     }
 });
 

--- a/neo.parse.js
+++ b/neo.parse.js
@@ -918,28 +918,21 @@ parse_statement.loop = function (the_loop) {
 };
 
 parse_statement.return = function (the_return) {
-    try {
-        if (now_function.parent === undefined) {
-            return error(the_return, "'return' wants to be in a function.");
-        }
-        loop.forEach(function (element, element_nr) {
-            if (element === "infinite") {
-                loop[element_nr] = "return";
-            }
-        });
-        if (is_line_break()) {
-            return error(the_return, "'return' wants a return value.");
-        }
-        the_return.zeroth = expression();
-        if (token === "}") {
-            return error(the_return, "Misplaced 'return'.");
-        }
-        the_return.disrupt = true;
-        the_return.return = true;
-        return the_return;
-    } catch (ignore) {
-        return the_error;
+    if (now_function.parent === undefined) {
+        return error(the_return, "'return' wants to be in a function.");
     }
+    loop.forEach(function (element, element_nr) {
+        if (element === "infinite") {
+            loop[element_nr] = "return";
+        }
+    });
+    if (is_line_break()) {
+        return error(the_return, "'return' wants a return value.");
+    }
+    the_return.zeroth = expression();
+    the_return.disrupt = true;
+    the_return.return = true;
+    return the_return;
 };
 
 parse_statement.var = function (the_var) {

--- a/neo.parse.js
+++ b/neo.parse.js
@@ -841,7 +841,7 @@ parse_statement.let = function (the_let) {
     }
     let readonly = left.readonly;
 
-// Now we consider the suffix operators ' []  .  [ ' and ' {'.
+// Now we consider the suffix operators ' []  .  [ ' and ' ('.
 
     while (true) {
         if (token === the_end) {

--- a/neo.parse.js
+++ b/neo.parse.js
@@ -1,6 +1,6 @@
 // neo.parse.js
 // Douglas Crockford
-// 2018-08-27
+// 2022-07-29
 
 // Public Domain
 
@@ -625,7 +625,7 @@ const functino = (function make_set(array, value = true) {
     return Object.freeze(object);
 }([
     "?", "|", "/\\", "\\/", "=", "≠", "<", "≥", ">", "≤",
-    "~", "≈", "+", "-", ">>", "<<", "*", "/", "[", "("
+    "~", "≈", "+", "-", ">>", "<<", "*", "/", "[]", "("
 ]));
 
 prefix("ƒ", function function_literal(the_function) {
@@ -642,9 +642,6 @@ prefix("ƒ", function function_literal(the_function) {
         if (the_operator.id === "(") {
             same_line();
             advance(")");
-        } else if (the_operator.id === "[") {
-            same_line();
-            advance("]");
         } else if (the_operator.id === "?") {
             same_line();
             advance("!");

--- a/neo.runtime.js
+++ b/neo.runtime.js
@@ -207,9 +207,6 @@ function record(zeroth, wunth) {
         if (wunth === undefined) {
             return Object.assign(newness, zeroth);
         }
-        if (typeof wunth === "object") {
-            return Object.assign(newness, zeroth, wunth);
-        }
         if (Array.isArray(wunth)) {
             wunth.forEach(function (key) {
                 let value = zeroth[key];
@@ -219,13 +216,16 @@ function record(zeroth, wunth) {
             });
             return newness;
         }
+        if (typeof wunth === "object") {
+            return Object.assign(newness, zeroth, wunth);
+        }
     }
     return fail("record");
 }
 
 function text(zeroth, wunth, twoth) {
     if (typeof zeroth === "string") {
-        return (zeroth.slice(big_float.number(wunth), big_float.number(twoth)));
+        return zeroth.slice(big_float.number(wunth), big_float.number(twoth));
     }
     if (big_float.is_big_float(zeroth)) {
         return big_float.string(zeroth, wunth);

--- a/neo.runtime.js
+++ b/neo.runtime.js
@@ -1,6 +1,6 @@
 // neo.runtime.js
 // Douglas Crockford
-// 2019-11-07
+// 2022-07-29
 
 /*property
     abs, add, and, array, assert_boolean, assign, bitand, bitdown, bitmask,
@@ -125,7 +125,7 @@ function set(container, key, value) {
     }
 }
 
-function array(zeroth, wunth, ...rest) {
+function array(zeroth, wunth, twoth) {
 
 // The 'array' function does the work of 'new Array', array'.fill',
 // array'.slice', 'Object.keys', string'.split', and more.
@@ -141,7 +141,7 @@ function array(zeroth, wunth, ...rest) {
             ? newness
             : (
                 typeof wunth === "function"
-                ? newness.map(wunth)
+                ? newness.fill().map(wunth)
                 : newness.fill(wunth)
             )
         );
@@ -150,7 +150,7 @@ function array(zeroth, wunth, ...rest) {
         if (typeof wunth === "function") {
             return zeroth.map(wunth);
         }
-        return zeroth.slice(big_float.number(wunth), big_float.number(rest[0]));
+        return zeroth.slice(big_float.number(wunth), big_float.number(twoth));
     }
     if (typeof zeroth === "object") {
         return Object.keys(zeroth);


### PR DESCRIPTION
I discovered and fixed some bugs in the Neo transpiler:
- `ƒ[]` was unparseable
- failure handlers were never run
- `array(number, function)` ignored the function argument
- a bad return statement corrupted the parse tree
- `record(record, array)` treated the array argument like an object